### PR TITLE
bump dompdf/dompdf version to 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^7.0",
-    "dompdf/dompdf": "^0.7",
+    "dompdf/dompdf": "^0.7 || ^0.8",
     "symfony/framework-bundle": "^2.8.6 || ^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
Because of dompdf/dompdf/issues/1272 i was trying to require the latest release of dompdf/dompdf, which is not possible because of `"dompdf/dompdf": "^0.7"` instead of `"dompdf/dompdf": "~0.7".
So i raised the required version of dompdf here :-)