### PR TITLE
Replace DompdfWrapperInterface::streamHtml with DompdfWrapperInterface::getStreamResponse

### DIFF
--- a/src/Wrapper/DompdfWrapper.php
+++ b/src/Wrapper/DompdfWrapper.php
@@ -38,8 +38,8 @@ final class DompdfWrapper implements DompdfWrapperInterface
     }
 
     /**
-     * @param string $html
-     * @param string $filename
+     * @param string               $html     The html sourcecode to render
+     * @param string               $filename The name of the document
      * @param array<string, mixed> $options  The rendering options (see dompdf docs)
      */
     public function streamHtml(string $html, string $filename, array $options = []): void
@@ -54,19 +54,6 @@ final class DompdfWrapper implements DompdfWrapperInterface
         }
 
         $pdf->stream($filename, $options);
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function getStreamResponse(string $html, string $filename, array $options = []): StreamedResponse
-    {
-        $response = new StreamedResponse();
-        $response->setCallback(function () use ($html, $filename, $options): void {
-            $this->streamHtml($html, $filename, $options);
-        });
-
-        return $response;
     }
 
     public function getPdf(string $html, array $options = []): string
@@ -87,5 +74,18 @@ final class DompdfWrapper implements DompdfWrapperInterface
         }
 
         return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function getStreamResponse(string $html, string $filename, array $options = []): StreamedResponse
+    {
+        $response = new StreamedResponse();
+        $response->setCallback(function () use ($html, $filename, $options): void {
+            $this->streamHtml($html, $filename, $options);
+        });
+
+        return $response;
     }
 }

--- a/src/Wrapper/DompdfWrapper.php
+++ b/src/Wrapper/DompdfWrapper.php
@@ -37,6 +37,11 @@ final class DompdfWrapper implements DompdfWrapperInterface
         $this->eventDispatcher = $eventDispatcher;
     }
 
+    /**
+     * @param string $html
+     * @param string $filename
+     * @param array<string, mixed> $options  The rendering options (see dompdf docs)
+     */
     public function streamHtml(string $html, string $filename, array $options = []): void
     {
         $pdf = $this->dompdfFactory->create($options);

--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -20,7 +20,7 @@ interface DompdfWrapperInterface
      * Renders a pdf document and streams it to the browser.
      *
      * @param string               $html     The html sourcecode to render
-     * @param string               $filename The name of the docuemtn
+     * @param string               $filename The name of the document
      * @param array<string, mixed> $options  The rendering options (see dompdf docs)
      *
      * @deprecated use getStreamResponse instead
@@ -29,7 +29,7 @@ interface DompdfWrapperInterface
 
     /**
      * @param string               $html     The html sourcecode to render
-     * @param string               $filename The name of the docuement
+     * @param string               $filename The name of the document
      * @param array<string, mixed> $options  The rendering options (see dompdf docs)
      * @return StreamedResponse
      */

--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Nucleos\DompdfBundle\Wrapper;
 
 use Nucleos\DompdfBundle\Exception\PdfException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 interface DompdfWrapperInterface
 {
@@ -25,6 +26,13 @@ interface DompdfWrapperInterface
      * @deprecated use getStreamResponse instead
      */
     public function streamHtml(string $html, string $filename, array $options = []): void;
+
+    /**
+     * @param array<string, mixed> $options
+     * @return StreamedResponse
+     */
+    public function getStreamResponse(string $html, string $filename, array $options = []): StreamedResponse;
+
 
     /**
      * Renders a pdf document and return the binary content.

--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -28,7 +28,9 @@ interface DompdfWrapperInterface
     public function streamHtml(string $html, string $filename, array $options = []): void;
 
     /**
-     * @param array<string, mixed> $options
+     * @param string               $html     The html sourcecode to render
+     * @param string               $filename The name of the docuement
+     * @param array<string, mixed> $options  The rendering options (see dompdf docs)
      * @return StreamedResponse
      */
     public function getStreamResponse(string $html, string $filename, array $options = []): StreamedResponse;

--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -31,10 +31,8 @@ interface DompdfWrapperInterface
      * @param string               $html     The html sourcecode to render
      * @param string               $filename The name of the document
      * @param array<string, mixed> $options  The rendering options (see dompdf docs)
-     * @return StreamedResponse
      */
     public function getStreamResponse(string $html, string $filename, array $options = []): StreamedResponse;
-
 
     /**
      * Renders a pdf document and return the binary content.

--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -17,17 +17,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 interface DompdfWrapperInterface
 {
     /**
-     * Renders a pdf document and streams it to the browser.
-     *
-     * @param string               $html     The html sourcecode to render
-     * @param string               $filename The name of the document
-     * @param array<string, mixed> $options  The rendering options (see dompdf docs)
-     *
-     * @deprecated use getStreamResponse instead
-     */
-    public function streamHtml(string $html, string $filename, array $options = []): void;
-
-    /**
      * @param string               $html     The html sourcecode to render
      * @param string               $filename The name of the document
      * @param array<string, mixed> $options  The rendering options (see dompdf docs)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

https://github.com/nucleos/NucleosDompdfBundle/issues/171

Closes #{171}

## Subject

Fixed phpstan error message : 
Call to an undefined method Nucleos\DompdfBundle\Wrapper\DompdfWrapperInterface::getStreamResponse().
