### PR TITLE
Introduce DompdfWrapperInterface:: getStreamResponse method

### DIFF
--- a/src/Wrapper/DompdfWrapperInterface.php
+++ b/src/Wrapper/DompdfWrapperInterface.php
@@ -13,6 +13,9 @@ namespace Nucleos\DompdfBundle\Wrapper;
 
 use Nucleos\DompdfBundle\Exception\PdfException;
 
+/**
+ * @method StreamedResponse getStreamResponse(string $html, string $filename, array $options = [])
+ */
 interface DompdfWrapperInterface
 {
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #373 
## Subject

<!-- Describe your Pull Request content here -->

Add `@method` for `getStreamResponse()` to DompdfWrapperInterface to remove IDE `method not found` warning.