### PR TITLE
Update NucleosDompdfExtension.php Extension Injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,17 +38,17 @@
     "require": {
         "php": "^8.1",
         "dompdf/dompdf": "^1.0.0 || ^2.0.0 || ^3.0.0",
-        "symfony/config": "^6.4 || ^7.0 || ^7.1",
-        "symfony/dependency-injection": "^6.4 || ^7.0 || ^7.1",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/event-dispatcher-contracts": "^1.1 || ^2.0 || ^3.0",
-        "symfony/expression-language": "^6.4 || ^7.0 || ^7.1",
-        "symfony/framework-bundle": "^6.4 || ^7.0 || ^7.1",
-        "symfony/http-foundation": "^6.4 || ^7.0 || ^7.1",
-        "symfony/http-kernel": "^6.4 || ^7.0 || ^7.1"
+        "symfony/expression-language": "^6.4 || ^7.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "symfony/http-foundation": "^6.4 || ^7.0",
+        "symfony/http-kernel": "^6.4 || ^7.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0.1",
-        "symfony/browser-kit": "^6.4 || ^7.0 || ^7.1"
+        "symfony/browser-kit": "^6.4 || ^7.0"
     },
     "suggest": {
         "symfony/event-dispatcher": "If you need to modify the PDF rendering"

--- a/composer.json
+++ b/composer.json
@@ -38,17 +38,17 @@
     "require": {
         "php": "^8.1",
         "dompdf/dompdf": "^1.0.0 || ^2.0.0 || ^3.0.0",
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/config": "^6.4 || ^7.0 || ^7.1",
+        "symfony/dependency-injection": "^6.4 || ^7.0 || ^7.1",
         "symfony/event-dispatcher-contracts": "^1.1 || ^2.0 || ^3.0",
-        "symfony/expression-language": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/http-foundation": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0"
+        "symfony/expression-language": "^6.4 || ^7.0 || ^7.1",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^7.1",
+        "symfony/http-foundation": "^6.4 || ^7.0 || ^7.1",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^7.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0.1",
-        "symfony/browser-kit": "^6.4 || ^7.0"
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^7.1"
     },
     "suggest": {
         "symfony/event-dispatcher": "If you need to modify the PDF rendering"

--- a/src/DependencyInjection/NucleosDompdfExtension.php
+++ b/src/DependencyInjection/NucleosDompdfExtension.php
@@ -14,7 +14,7 @@ namespace Nucleos\DompdfBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 final class NucleosDompdfExtension extends Extension
 {

--- a/src/DependencyInjection/NucleosDompdfExtension.php
+++ b/src/DependencyInjection/NucleosDompdfExtension.php
@@ -13,8 +13,8 @@ namespace Nucleos\DompdfBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader;
 
 final class NucleosDompdfExtension extends Extension
 {

--- a/src/Wrapper/DompdfWrapper.php
+++ b/src/Wrapper/DompdfWrapper.php
@@ -25,7 +25,7 @@ final class DompdfWrapper implements DompdfWrapperInterface
 
     private ?EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(DompdfFactoryInterface $dompdfFactory, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(DompdfFactoryInterface $dompdfFactory, ?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->dompdfFactory   = $dompdfFactory;
         $this->eventDispatcher = $eventDispatcher;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Fix for Symfony 7.1

<!-- Describe your Pull Request content here -->
After upgrading to Symfony 7.1 I encountered a deprecation notice on your bundle.
>The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice.

